### PR TITLE
New ad types, enable analytics only in production mode

### DIFF
--- a/app/helpers/ads_helper.rb
+++ b/app/helpers/ads_helper.rb
@@ -8,4 +8,20 @@ module AdsHelper
   def filtered?
     params[:kind].present? || params[:city].present?
   end
+
+  def kind_tag(ad)
+    color_class = if ad.accomodation?
+                  'is-success'
+                elsif ad.transportation?
+                  'is-info'
+                elsif ad.repair_service?
+                  'is-warning'
+                elsif ad.medical_help?
+                  'is-danger'
+                else
+                  'is-white'
+                end
+                       
+    tag.span(ad.kind, class: "tag #{color_class}")
+  end
 end

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -15,6 +15,8 @@
 #  updated_at  :datetime         not null
 #
 class Ad < ApplicationRecord
+  KINDS = %w[Smještaj Prijevoz Prijava\ štete Usluge\ popravke]
+
   validates :city, presence: true
   validates :description, presence: true
   validates :kind, presence: true

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -15,7 +15,7 @@
 #  updated_at  :datetime         not null
 #
 class Ad < ApplicationRecord
-  KINDS = %w[Smještaj Prijevoz Prijava\ štete Usluge\ popravke]
+  KINDS = ['Smještaj', 'Prijevoz', 'Usluga popravka', 'Medicinska pomoć'].freeze
 
   validates :city, presence: true
   validates :description, presence: true
@@ -29,5 +29,21 @@ class Ad < ApplicationRecord
     if phone.blank? && email.blank?
       errors.add(:base, "Email ili telefon su obavezni")
     end
+  end
+
+  def accomodation?
+    kind == 'Smještaj'
+  end
+
+  def transportation?
+    kind == 'Prijevoz'
+  end
+
+  def repair_service?
+    kind == 'Usluga popravka'
+  end
+
+  def medical_help?
+    kind == 'Medicinska pomoć'
   end
 end

--- a/app/views/ads/index.html.erb
+++ b/app/views/ads/index.html.erb
@@ -66,14 +66,13 @@
 <% @ads.each do |ad| %>
   <div class="card" style="margin-bottom:30px">
     <div class="card-content">
-      <div class="media">
-        <div class="media-content">
-          <p class="title is-4"><%= ad.kind %></p>
-        </div>
-      </div>
-
       <div class="content">
         <div class="columns is-mobile">
+          <div class="column is-narrow">
+            <div class="tags">
+              <%= kind_tag ad %>
+            </div>
+          </div>
           <div class="column is-narrow">
             <div class="tags has-addons">
               <span class="tag">Grad</span>

--- a/app/views/ads/index.html.erb
+++ b/app/views/ads/index.html.erb
@@ -17,7 +17,7 @@
           <div class="field">
             <div class="control">
               <div class="select">
-                <%= select_tag :kind, options_for_select(%w[Smještaj Prijevoz], params[:kind]), prompt: "-- Svi tipovi --" %>
+                <%= select_tag :kind, options_for_select(Ad::KINDS, params[:kind]), prompt: "-- Svi tipovi --" %>
               </div>
             </div>
           </div>

--- a/app/views/ads/new.html.erb
+++ b/app/views/ads/new.html.erb
@@ -20,7 +20,7 @@
     <%= f.label :kind, class: "label" %>
     <div class="control">
       <div class="select">
-        <%= f.select :kind, %w[Smještaj Prijevoz] %>
+        <%= f.select :kind, Ad::KINDS %>
       </div>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,13 +9,15 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs=" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-108052769-3"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-108052769-3');
-    </script>
+    <% if Rails.env.production? %>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Rails.application.credentials.dig(:google_analytics) %>"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '<%= Rails.application.credentials.dig(:google_analytics) %>');
+      </script>
+    <% end %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>


### PR DESCRIPTION
Fixes https://github.com/vlado/earthquake-croatia/issues/8

Adds two new ad types:
- Prijava štete
- Usluge popravke

Also, disables analytics in anything other than production mode

How it looks like:
![Screenshot from 2020-12-30 16-58-14](https://user-images.githubusercontent.com/7805837/103365874-66df8400-4ac1-11eb-92fe-b7c96101ce6a.png)
