### PR TITLE
Add address field to Ad

### DIFF
--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -21,6 +21,6 @@ class AdsController < ApplicationController
   private
 
   def ad_params
-    params.require(:ad).permit(:kind, :city, :description, :email, :phone, :zip, :consent)
+    params.require(:ad).permit(:kind, :city, :description, :email, :phone, :zip, :consent, :address)
   end
 end

--- a/app/views/ads/index.html.erb
+++ b/app/views/ads/index.html.erb
@@ -80,6 +80,14 @@
               <span class="tag is-info"><%= ad.city %></span>
             </div>
           </div>
+          <% if ad.address.present? %>
+            <div class="column is-narrow">
+              <div class="tags has-addons">
+                <span class="tag">Adresa</span>
+                <span class="tag is-info"><%= ad.address %></span>
+              </div>
+            </div>
+          <% end %>
           <% if ad.zip.present? %>
             <div class="column is-narrow">
               <div class="tags has-addons">
@@ -96,6 +104,9 @@
 
         <div class="columns">
           <div class="column is-hidden-mobile">Grad: <b><%= city_and_zip ad %></b></div>
+          <% if ad.address.present? %>
+            <div class="column is-hidden-mobile">Adresa: <b><%= ad.address %></b></div>
+          <% end %>
           <div class="column">Telefon: <b><%= tel_to ad.phone %></b></div>
           <div class="column">Objavljeno: <b><%= ad.created_at.strftime("%d.%m.%Y. %H:%M") %></b></div>
         </div>

--- a/app/views/ads/new.html.erb
+++ b/app/views/ads/new.html.erb
@@ -37,6 +37,13 @@
   </div>
 
   <div class="field">
+    <%= f.label :address, class: "label" %>
+    <div class="control">
+      <%= f.text_field :address, class: "input" %>
+    </div>
+  </div>
+
+  <div class="field">
     <%= f.label :phone, "Kontakt telefon", class: "label" %>
     <div class="control">
       <%= f.text_field :phone, class: "input" %>

--- a/config/locales/app.hr.yml
+++ b/config/locales/app.hr.yml
@@ -10,3 +10,4 @@ hr:
         phone: Telefon
         zip: Poštanski broj
         consent: Privola
+        address: Adresa

--- a/db/migrate/20201230150837_add_address_to_ad.rb
+++ b/db/migrate/20201230150837_add_address_to_ad.rb
@@ -1,0 +1,5 @@
+class AddAddressToAd < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ads, :address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_29_233911) do
+ActiveRecord::Schema.define(version: 2020_12_30_150837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2020_12_29_233911) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "consent"
+    t.string "address"
   end
 
 end


### PR DESCRIPTION
Related issue: https://github.com/vlado/earthquake-croatia/issues/7

* Adds the address  column to Ad model
* Adds the address input to Ad form
* Displays the address on Ad index pages

Outstanding questions:

Should we validate the address field?
Do we want to put the address field somewhere else on the form/index pages?