### PR TITLE
Show time ago instead of timestamp on index page

### DIFF
--- a/app/views/ads/index.html.erb
+++ b/app/views/ads/index.html.erb
@@ -95,9 +95,8 @@
         <hr>
 
         <div class="columns">
-          <div class="column is-hidden-mobile">Grad: <b><%= city_and_zip ad %></b></div>
           <div class="column">Telefon: <b><%= tel_to ad.phone %></b></div>
-          <div class="column">Objavljeno: <b><%= ad.created_at.strftime("%d.%m.%Y. %H:%M") %></b></div>
+          <div class="column">Objavljeno: <b>prije <%= time_ago_in_words ad.created_at %></b></div>
         </div>
       </div>
     </div>

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -104,9 +104,9 @@ hr:
         many: "%{count} sekundi"
         other: "%{count} sekundi"
       x_minutes:
-        one: "%{count} minuta"
+        one: "%{count} minute"
         few: "%{count} minute"
-        many: "%{count} minuta"
+        many: "%{count} minute"
         other: "%{count} minuta"
       x_days:
         one: "%{count} dan"


### PR DESCRIPTION
This PR removes redundant city info from the index page and replaces timestamp with time ago.