### PR TITLE
New ad: Fix clicking on checkbox label

### DIFF
--- a/app/views/ads/new.html.erb
+++ b/app/views/ads/new.html.erb
@@ -72,7 +72,7 @@
   <div class="field">
     <div class="control">
       <%= f.check_box :consent %>
-      <%= f.label :consent_at, 'Pristajem da se oglas spremi sa svim navedenim podacima i pristajem da se oglas javno objavi.', class: "checkbox" %>
+      <%= f.label :consent, 'Pristajem da se oglas spremi sa svim navedenim podacima i pristajem da se oglas javno objavi.', class: "checkbox" %>
     </div>
   </div>
 


### PR DESCRIPTION
Checkbox field name is `:consent`, not `:consent_at`