### PR TITLE
Fix mobile view

### DIFF
--- a/app/views/ads/index.html.erb
+++ b/app/views/ads/index.html.erb
@@ -115,8 +115,14 @@
 <div class="content">
   <h3 class="title is-3">Ostale stranice sa popisima ponude smještaja i prijevoza:</h3>
   <ul>
-    <li><a href="https://docs.google.com/document/d/15kSw0O1jtZYTeLh3jZg2XeGFbNbavIBsA0u_PvK8YRs/mobilebasic"  target="_blank">https://docs.google.com/document/d/15kSw0O1jtZYTeLh3jZg2XeGFbNbavIBsA0u_PvK8YRs/mobilebasic</a></li>
-    <li><a href="https://docs.google.com/document/d/1yUxHtKCkkXEQ8tXTD2bODbisxwF5Q9zvPJoU27vQGUM/edit?fbclid=IwAR0g1F__7avcVpOlf__NQgBq626LDmDNyz42k545TT5MCjTLMvf4De9tvMs" target="_blank">https://docs.google.com/document/d/1yUxHtKCkkXEQ8tXTD2bODbisxwF5Q9zvPJoU27vQGUM/edit?fbclid=IwAR0g1F__7avcVpOlf__NQgBq626LDmDNyz42k545TT5MCjTLMvf4De9tvMs</a></li>
-    <li><a href="https://www.facebook.com/groups/155412969344431/permalink/155812429304485/" target="_blank">https://www.facebook.com/groups/155412969344431/permalink/155812429304485/</a></li>
+    <li><a href="https://docs.google.com/document/d/15kSw0O1jtZYTeLh3jZg2XeGFbNbavIBsA0u_PvK8YRs/mobilebasic"  target="_blank">
+      Pomoć obiteljima iz Petrinje, Siska i okolice - kontakti, smještaj i prijevoz - Google doc (preview)
+    </a></li>
+    <li><a href="https://docs.google.com/document/d/1yUxHtKCkkXEQ8tXTD2bODbisxwF5Q9zvPJoU27vQGUM/edit?fbclid=IwAR0g1F__7avcVpOlf__NQgBq626LDmDNyz42k545TT5MCjTLMvf4De9tvMs" target="_blank">
+      Pomoć za Petrinju - Google doc
+    </a></li>
+    <li><a href="https://www.facebook.com/groups/155412969344431/permalink/155812429304485/" target="_blank">
+      POMOC GLINI, PETRINJI, SISKU i okolnim mjestima - Facebook grupa
+    </a></li>
   </ul>
 </div>

--- a/app/views/ads/index.html.erb
+++ b/app/views/ads/index.html.erb
@@ -124,5 +124,8 @@
     <li><a href="https://www.facebook.com/groups/155412969344431/permalink/155812429304485/" target="_blank">
       POMOC GLINI, PETRINJI, SISKU i okolnim mjestima - Facebook grupa
     </a></li>
+    <li><a href="https://potres2020.openit.hr/views/map" target="_blank">
+      Potres 2020 - mapa pomoći
+    </a></li>
   </ul>
 </div>


### PR DESCRIPTION
The long links in the page footer broke zoom on mobile.

Before:
<img width="160" alt="Screen Shot 2020-12-31 at 08 44 40" src="https://user-images.githubusercontent.com/67437/103400190-7eac1c00-4b44-11eb-8091-dc63cd0547ef.png">


After:
<img width="160" alt="Screen Shot 2020-12-31 at 08 44 54" src="https://user-images.githubusercontent.com/67437/103400194-823fa300-4b44-11eb-825b-ed0128d5209b.png">

