### PR TITLE
Generate seed data for easier local development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ group :development do
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+
+  gem 'ffaker'
+  gem 'pry-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,9 +79,11 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     erubi (1.10.0)
+    ffaker (2.17.0)
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -111,6 +113,11 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (5.1.1)
       nio4r (~> 2.0)
@@ -214,10 +221,12 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  ffaker
   invisible_captcha
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)
+  pry-rails
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.0)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ rails db:migrate
 rails webpacker:install
 ```
 
+### Optionally add dummy data
+
+```bash
+rails db:seed
+```
+
 ### Run server locally
 
 ```bash

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,22 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+ads_data = []
+
+100.times do
+  ads_data << {
+    city: %w[Slatina Neum Makarska Varaždin Varazdin Bibinje Zagreb Križevci Krizevci].sample,
+    zip: rand(10_000..99_000),
+    phone: '0' + rand(9_000_00_00..9_999_99_99).to_s,
+    description: FFaker::Lorem.paragraph,
+    email: rand(0..100) < 40 ? FFaker::Internet.email : nil, # 40% chance ad has email
+    kind: Ad::KINDS.sample,
+    consent: true,
+    address: FFaker::Address.street_name
+  }
+end
+
+Ad.create!(ads_data)
+
+puts "Generated 100 ads"


### PR DESCRIPTION
Added a simple seed data for easier local development.

I hope you don't mind that I used ffaker gem for lorem ipsum text (ad description) and I also added pry-rails gem for better rails console DX.
Let me know if I should remove it.