### PR TITLE
Redirect all traffic to www.potres-petrinja.hr and force ssl.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,10 @@ gem "jbuilder", "~> 2.7"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false
 
+group :production do
+  gem "rack-host-redirect"
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,8 @@ GEM
     puma (5.1.1)
       nio4r (~> 2.0)
     rack (2.2.3)
+    rack-host-redirect (1.3.0)
+      rack
     rack-mini-profiler (2.3.0)
       rack (>= 1.2.0)
     rack-proxy (0.6.5)
@@ -251,6 +253,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-rails
   puma (~> 5.0)
+  rack-host-redirect
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.0)
   rubocop-rails (~> 2.3, >= 2.3.1)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,11 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+
+  config.middleware.insert_before ActionDispatch::SSL, Rack::HostRedirect, {
+    %w(potres.herokuapp.com potres-petrinja.hr) => "www.potres-petrinja.hr"
+  }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
We are redirecting all request to SSL in Cloudflare so we just need
to redirect eveything to www subdomain on app level

Closes https://github.com/vlado/earthquake-croatia/issues/37