### PR TITLE
external-links: Move external links on top

### DIFF
--- a/app/javascript/controllers/card_controller.js
+++ b/app/javascript/controllers/card_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = ["content"];
+
+  // ACTIONS
+
+  toggle() {
+    if (this.contentTarget.hidden) {
+      this.contentTarget.hidden = false;
+    } else {
+      this.contentTarget.hidden = true;
+    }
+  }
+}

--- a/app/views/ads/index.html.erb
+++ b/app/views/ads/index.html.erb
@@ -51,21 +51,3 @@
 <%= render @ads %>
 
 <%= will_paginate @ads, renderer: BulmaPagination::Rails, class: 'is-centered', previous_label: "&larr;", next_label: "&rarr;", inner_window: 1, outer_window: 0 %>
-
-<div class="content mt-6">
-  <h3 class="title is-3">Ostale stranice sa popisima ponude smještaja i prijevoza:</h3>
-  <ul>
-    <li><a href="https://docs.google.com/document/d/15kSw0O1jtZYTeLh3jZg2XeGFbNbavIBsA0u_PvK8YRs/mobilebasic"  target="_blank">
-      Pomoć obiteljima iz Petrinje, Siska i okolice - kontakti, smještaj i prijevoz - Google doc (preview)
-    </a></li>
-    <li><a href="https://docs.google.com/document/d/1yUxHtKCkkXEQ8tXTD2bODbisxwF5Q9zvPJoU27vQGUM/edit?fbclid=IwAR0g1F__7avcVpOlf__NQgBq626LDmDNyz42k545TT5MCjTLMvf4De9tvMs" target="_blank">
-      Pomoć za Petrinju - Google doc
-    </a></li>
-    <li><a href="https://www.facebook.com/groups/155412969344431/permalink/155812429304485/" target="_blank">
-      POMOC GLINI, PETRINJI, SISKU i okolnim mjestima - Facebook grupa
-    </a></li>
-    <li><a href="https://potres2020.openit.hr/views/map" target="_blank">
-      Potres 2020 - mapa pomoći
-    </a></li>
-  </ul>
-</div>

--- a/app/views/layouts/_links.html.erb
+++ b/app/views/layouts/_links.html.erb
@@ -1,0 +1,30 @@
+<div id="external-links" class="card mb-6" data-controller="card">
+  <header class="card-header">
+    <p class="card-header-title">
+      Vanjske poveznice s popisima ponude smještaja i prijevoza
+    </p>
+    <a href="javascript:void(0)" class="card-header-icon" aria-label="hide links" data-action="card#toggle">
+      <span class="icon">
+        <i class="fas fa-angle-down" aria-hidden="true"></i>
+      </span>
+    </a>
+  </header>
+  <div class="card-content" data-card-target="content" hidden="true">
+    <div class="content">
+      <ul>
+        <li><a href="https://docs.google.com/document/d/15kSw0O1jtZYTeLh3jZg2XeGFbNbavIBsA0u_PvK8YRs/mobilebasic"  target="_blank">
+          Pomoć obiteljima iz Petrinje, Siska i okolice - kontakti, smještaj i prijevoz - Google doc (preview)
+        </a></li>
+        <li><a href="https://docs.google.com/document/d/1yUxHtKCkkXEQ8tXTD2bODbisxwF5Q9zvPJoU27vQGUM/edit?fbclid=IwAR0g1F__7avcVpOlf__NQgBq626LDmDNyz42k545TT5MCjTLMvf4De9tvMs" target="_blank">
+          Pomoć za Petrinju - Google doc
+        </a></li>
+        <li><a href="https://www.facebook.com/groups/155412969344431/permalink/155812429304485/" target="_blank">
+          POMOC GLINI, PETRINJI, SISKU i okolnim mjestima - Facebook grupa
+        </a></li>
+        <li><a href="https://potres2020.openit.hr/views/map" target="_blank">
+          Potres 2020 - mapa pomoći
+        </a></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,7 @@
     </section>
     <section class="section">
       <div class="container">
+        <%= render 'layouts/links' %>
         <%= yield %>
       </div>
     </section>


### PR DESCRIPTION
Moves useful external links to the top as a by default uncollapsed card
![IMG_0210](https://user-images.githubusercontent.com/1616329/103455842-e7d09280-4cf0-11eb-8565-9efdb272f7e1.PNG)

How it looks after collapsing
![IMG_0211](https://user-images.githubusercontent.com/1616329/103455860-1189b980-4cf1-11eb-98a2-0739d03ae346.PNG)
