### PR TITLE
Show full address in one tag to save space on mobile.

### DIFF
--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -49,6 +49,6 @@ class Ad < ApplicationRecord
 
   def full_address
     zip_and_city = [zip, city].select(&:present?).join(" ")
-    [address, zip_and_city].join(", ")
+    [address, zip_and_city].select(&:present?).join(", ")
   end
 end

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -47,7 +47,8 @@ class Ad < ApplicationRecord
     [id, kind.parameterize, city.parameterize].join("-")
   end
 
-  def maps_query
-    [address.gsub(" ", "+"), zip, city].select(&:present?).join(",+")
+  def full_address
+    zip_and_city = [zip, city].select(&:present?).join(" ")
+    [address, zip_and_city].join(", ")
   end
 end

--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -10,42 +10,23 @@
 
         <div class="control">
           <div class="tags has-addons">
-            <span class="tag">Grad</span>
-            <span class="tag is-info"><%= ad.city %></span>
+            <span class="tag">Adresa</span>
+            <span class="tag is-info"><%= ad.full_address %></span>
           </div>
         </div>
 
-        <% if ad.zip.present? %>
-          <div class="control">
+        <div class="control">
+          <a href="<%= maps_url(ad.full_address) %>" target="_blank" class="is-block">
             <div class="tags has-addons">
-              <span class="tag">Poštanski broj</span>
-              <span class="tag is-info"><%= ad.zip %></span>
+              <span class="tag">Lokacija na karti</span>
+              <span class="tag is-info">
+                <span class="icon">
+                  <i class="fas fa-map-marked-alt"></i>
+                </span>
+              </span>
             </div>
-          </div>
-        <% end %>
-
-        <% if ad.address.present? %>
-          <div class="control">
-            <div class="tags has-addons">
-              <span class="tag">Adresa</span>
-              <span class="tag is-info"><%= ad.address %></span>
-            </div>
-          </div>
-          <% if ad.maps_query.present? %>
-            <div class="control">
-              <a href="<%= maps_url(ad.maps_query) %>" target="_blank" class="is-block">
-                <div class="tags has-addons">
-                  <span class="tag">Lokacija na karti</span>
-                  <span class="tag is-info">
-                    <span class="icon">
-                      <i class="fas fa-map-marked-alt"></i>
-                    </span>
-                  </span>
-                </div>
-              </a>
-            </div>
-          <% end %>
-        <% end %>
+          </a>
+        </div>
       </div>
 
       <%= simple_format ad.description %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Potres - Petrinja, Sisak i okolna mjesta</title>
+    <title>Potres - Petrinja, Sisak, Glina i okolna mjesta</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
@@ -26,7 +26,7 @@
     <section class="section">
       <div class="container">
         <h1 class="title">Pomozimo žrtvama potresa</h1>
-        <h2 class="subtitle">Petrinja, Sisaki, Glina i okolna mjesta</h2>
+        <h2 class="subtitle">Petrinja, Sisak, Glina i okolna mjesta</h2>
         <%= yield %>
       </div>
     </section>


### PR DESCRIPTION
And I think it also looks better :)

<img width="345" alt="Screenshot 2021-01-02 at 01 06 25" src="https://user-images.githubusercontent.com/5148/103448254-2f2a3500-4c97-11eb-85dd-55a0ac320520.png">

@berislavbabic I notice that links with full address work fine on google maps so I just used that to simplify stuff.