### PR TITLE
Fix long address display by spliting it to "address" and "zip and city"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-debug.log*
 
 # OSX specific
 .DS_Store
+.foreman

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+webpack: bin/webpack-dev-server

--- a/README.md
+++ b/README.md
@@ -96,8 +96,15 @@ rails db:seed
 #### Run server
 
 ```bash
-rails s
+bin/rails server
+bin/webpack-dev-server
 ```
+
+or if you use foreman
+
+```bash
+foreman start -f Procfile.dev
+``
 
 ## Statement
 

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -48,7 +48,10 @@ class Ad < ApplicationRecord
   end
 
   def full_address
-    zip_and_city = [zip, city].select(&:present?).join(" ")
     [address, zip_and_city].select(&:present?).join(", ")
+  end
+
+  def zip_and_city
+    [zip, city].select(&:present?).join(" ")
   end
 end

--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -10,10 +10,19 @@
 
         <div class="control">
           <div class="tags has-addons">
-            <span class="tag">Adresa</span>
-            <span class="tag is-info"><%= ad.full_address %></span>
+            <span class="tag">Grad</span>
+            <span class="tag is-info"><%= ad.zip_and_city%></span>
           </div>
         </div>
+
+        <% if ad.address.present? %>
+          <div class="control">
+            <div class="tags has-addons">
+              <span class="tag">Adresa</span>
+              <span class="tag is-info"><%= ad.address %></span>
+            </div>
+          </div>
+        <% end %>
 
         <div class="control">
           <a href="<%= maps_url(ad.full_address) %>" target="_blank" class="is-block">


### PR DESCRIPTION
This PR https://github.com/vlado/earthquake-croatia/pull/79 broke the display of very long address on mobile.

![F11F3393-B400-4F74-85A5-21325D537DB8_1_102_o](https://user-images.githubusercontent.com/5148/103455464-b7d3c000-4ced-11eb-89b6-f82daf72f238.jpeg)

This is a quick fix before the redesign.