### PR TITLE
Fix SVG icon for Chrome and Safari

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,11 @@
 @import "toastr/toastr";
 @import "hero";
 
+.icon > svg {
+  width: inherit;
+  height: inherit;
+}
+
 .toast-success {
   background-color: #48c774;
 }


### PR DESCRIPTION
@vlado 

It was working fine on Firefox and I didn't check other browsers (mea culpa).
Should be good now.