### PR TITLE
Ad action menu style proposal 

### DIFF
--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -49,7 +49,7 @@
       <hr>
       <div class="columns" data-controller="clipboard">
         <div class="column">
-          <a class="button" href="<%= ad_url(ad.to_param) %>">
+          <%= link_to "Otvori oglas", ad_path(ad.to_param), class: "button" %>
             Otvori oglas
           </a>
           <button data-clipboard-target="button" class="button" data-clipboard-text="<%= ad_url(ad.to_param) %>">

--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -48,8 +48,10 @@
       </div>
       <hr>
       <div class="columns" data-controller="clipboard">
-        <div class="column">URL oglasa: <%= link_to ad_url(ad.to_param), ad_url(ad.to_param) %></div>
         <div class="column">
+          <a class="button" href="<%= ad_url(ad.to_param) %>">
+            Otvori oglas
+          </a>
           <button data-clipboard-target="button" class="button" data-clipboard-text="<%= ad_url(ad.to_param) %>">
             Kopiraj poveznicu na oglas
           </button>


### PR DESCRIPTION
<img width="1532" alt="Screenshot 2021-01-02 at 20 58 39" src="https://user-images.githubusercontent.com/1666889/103465617-f85b2a00-4d3d-11eb-9914-651d9f7eae89.png">

Had some feedback on the full URL being shown out on each ad, proposing the above action menu style for consistency.