### PR TITLE
Fix seeds by adding service to the Ad generator

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,8 @@ number_of_ads.times do
     email: rand(0..number_of_ads) < 40 ? FFaker::Internet.email : nil, # 40% chance ad has email
     kind: Ad::KINDS.sample,
     consent: true,
-    address: FFaker::Address.street_name
+    address: FFaker::Address.street_name,
+    service: Ad::SERVICES[rand(Ad::SERVICES.count-1)]
   }
 end
 


### PR DESCRIPTION
Service field has been added to the Ad model with validations for it to be present within a range of specific values.

This PR updates the seed file so that it generates service field when generating ads.