### PR TITLE
Add missing index on Ad.kind; Fix db:seeds

### DIFF
--- a/db/migrate/20210103235304_add_index_to_kind_on_ads.rb
+++ b/db/migrate/20210103235304_add_index_to_kind_on_ads.rb
@@ -1,0 +1,5 @@
+class AddIndexToKindOnAds < ActiveRecord::Migration[6.1]
+  def change
+    add_index :ads, :kind, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_03_163430) do
+ActiveRecord::Schema.define(version: 2021_01_03_235304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ number_of_ads.times do
     kind: Ad::KINDS.sample,
     consent: true,
     address: FFaker::Address.street_name,
-    service: Ad::SERVICES[rand(Ad::SERVICES.count-1)]
+    category: Ad::CATEGORIES.sample
   }
 end
 


### PR DESCRIPTION
@vlado we lost the index on kind due to this migration: https://github.com/vlado/earthquake-croatia/blob/master/db/migrate/20210101194804_rename_kind_to_service_on_ads.rb#L10

I'm adding it back in this PR as we're using that column to query the db when filtering:
https://github.com/vlado/earthquake-croatia/blob/master/app/controllers/ads_controller.rb#L8