### PR TITLE
Fix accidentally incorrect schema

### DIFF
--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -7,6 +7,7 @@
 #  id          :bigint           not null, primary key
 #  address     :string
 #  category    :integer          default("accomodation"), not null
+#  city        :string
 #  consent     :boolean
 #  deleted_at  :datetime
 #  description :text
@@ -17,20 +18,15 @@
 #  zip         :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  city_id     :bigint           not null
 #
 # Indexes
 #
 #  index_ads_on_category    (category)
-#  index_ads_on_city_id     (city_id)
+#  index_ads_on_city        (city)
 #  index_ads_on_created_at  (created_at)
 #  index_ads_on_deleted_at  (deleted_at)
 #  index_ads_on_kind        (kind)
 #  index_ads_on_token       (token) UNIQUE
-#
-# Foreign Keys
-#
-#  fk_rails_...  (city_id => cities.id)
 #
 class Ad < ApplicationRecord
   CATEGORIES = %w[

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema.define(version: 2021_01_04_195316) do
   enable_extension "unaccent"
 
   create_table "ads", force: :cascade do |t|
+    t.string "city"
     t.string "zip"
     t.string "phone"
     t.text "description"
@@ -27,34 +28,14 @@ ActiveRecord::Schema.define(version: 2021_01_04_195316) do
     t.string "address"
     t.integer "kind", default: 0, null: false
     t.integer "category", default: 0, null: false
-    t.bigint "city_id", null: false
     t.string "token"
     t.datetime "deleted_at"
     t.index ["category"], name: "index_ads_on_category"
-    t.index ["city_id"], name: "index_ads_on_city_id"
+    t.index ["city"], name: "index_ads_on_city"
     t.index ["created_at"], name: "index_ads_on_created_at"
     t.index ["deleted_at"], name: "index_ads_on_deleted_at"
     t.index ["kind"], name: "index_ads_on_kind"
     t.index ["token"], name: "index_ads_on_token", unique: true
   end
 
-  create_table "cities", force: :cascade do |t|
-    t.string "area_name"
-    t.bigint "county_id"
-    t.string "name"
-    t.integer "zip_code"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["county_id"], name: "index_cities_on_county_id"
-  end
-
-  create_table "counties", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_counties_on_name"
-  end
-
-  add_foreign_key "ads", "cities"
-  add_foreign_key "cities", "counties"
 end

--- a/test/fixtures/ads.yml
+++ b/test/fixtures/ads.yml
@@ -5,6 +5,7 @@
 #  id          :bigint           not null, primary key
 #  address     :string
 #  category    :integer          default("accomodation"), not null
+#  city        :string
 #  consent     :boolean
 #  deleted_at  :datetime
 #  description :text
@@ -15,20 +16,15 @@
 #  zip         :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  city_id     :bigint           not null
 #
 # Indexes
 #
 #  index_ads_on_category    (category)
-#  index_ads_on_city_id     (city_id)
+#  index_ads_on_city        (city)
 #  index_ads_on_created_at  (created_at)
 #  index_ads_on_deleted_at  (deleted_at)
 #  index_ads_on_kind        (kind)
 #  index_ads_on_token       (token) UNIQUE
-#
-# Foreign Keys
-#
-#  fk_rails_...  (city_id => cities.id)
 #
 
 # one:

--- a/test/models/ad_test.rb
+++ b/test/models/ad_test.rb
@@ -7,6 +7,7 @@
 #  id          :bigint           not null, primary key
 #  address     :string
 #  category    :integer          default("accomodation"), not null
+#  city        :string
 #  consent     :boolean
 #  deleted_at  :datetime
 #  description :text
@@ -17,20 +18,15 @@
 #  zip         :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  city_id     :bigint           not null
 #
 # Indexes
 #
 #  index_ads_on_category    (category)
-#  index_ads_on_city_id     (city_id)
+#  index_ads_on_city        (city)
 #  index_ads_on_created_at  (created_at)
 #  index_ads_on_deleted_at  (deleted_at)
 #  index_ads_on_kind        (kind)
 #  index_ads_on_token       (token) UNIQUE
-#
-# Foreign Keys
-#
-#  fk_rails_...  (city_id => cities.id)
 #
 require "test_helper"
 


### PR DESCRIPTION
Schema was pulled from one PR through testing
and accidentally merged with another PR which
broke db:setup rake task.

This corrects the schema to match the state of
master.