### PR TITLE
Edit/Delete proper styling in ad

### DIFF
--- a/app/assets/images/pen.svg
+++ b/app/assets/images/pen.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+</svg>

--- a/app/assets/images/trash.svg
+++ b/app/assets/images/trash.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+</svg>

--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -28,8 +28,20 @@
                 Kopiraj poveznicu
               </a>
               <% if ad.editable? %>
-                <%= link_to "Uredi oglas", new_ad_token_path(ad, a: "edit"), class: "dropdown-item is-flex is-align-items-center" %>
-                <%= link_to "Obriši oglas", new_ad_token_path(ad, a: "delete"), class: "dropdown-item is-flex is-align-items-center" %>
+                <hr class="dropdown-divider">
+                <a class="dropdown-item is-flex is-align-items-center" href="<%= new_ad_token_path(ad, a: "edit") %>" >
+                  <span class="icon is-small mr-2">
+                    <%= inline_svg_tag('pen.svg', aria: true) %>
+                  </span>
+                  Uredi oglas
+                </a>
+
+                <a class="dropdown-item is-flex is-align-items-center has-text-danger" href="<%= new_ad_token_path(ad, a: "delete") %>" >
+                  <span class="icon is-small mr-2">
+                    <%= inline_svg_tag('trash.svg', aria: true) %>
+                  </span>
+                  Obriši oglas
+                </a>
               <% end %>
             </div>
           </div>
@@ -37,7 +49,7 @@
       </div>
 
       <div class="content">
-        <h3 class="is-size-5"><%= ad.zip_and_city %></h3>
+        <h3 class="is-size-5"><%= ad.city %></h3>
 
         <%= simple_format ad.description %>
 
@@ -47,16 +59,19 @@
               <span class="icon mr-2">
                 <%= inline_svg_tag('location.svg', aria: true) %>
               </span>
-              <%= ad.address %>
-            </div>
 
-            <div class="mt-2">
-              <a href="<%= maps_url(ad.full_address) %>" target="_blank" class="is-flex">
-                <span class="icon mr-2">
-                  <%= inline_svg_tag('map.svg', aria: true) %>
-                </span>
-                Lokacija na karti
-              </a>
+              <ul class="m-0">
+                <li class="is-block"><%= ad.address %></li>
+                <li class="is-block"><%= ad.zip_and_city %></li>
+                <li class="is-block">
+                  <a href="<%= maps_url(ad.full_address) %>" target="_blank" class="is-flex">
+                  <span class="icon mr-2">
+                    <%= inline_svg_tag('map.svg', aria: true) %>
+                  </span>
+                  Lokacija na karti
+                  </a>
+                </li>
+              </ul>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
2 things actually:

- Proper styling for edit/delete actions
<img width="295" alt="Screen Shot 2021-01-06 at 21 47 27" src="https://user-images.githubusercontent.com/1909957/103822876-d4168a80-5068-11eb-864f-cbcc0c91590e.png">


- Implement suggestions of @vfonic in #108 
  - Remove zip code from card title
  - Add zip code and city to address
  - Move `Check location on map` to address (we could make the whole address clickable but let's keep it like this for now)
<img width="350" alt="Screen Shot 2021-01-06 at 21 47 41" src="https://user-images.githubusercontent.com/1909957/103822874-d2e55d80-5068-11eb-94a3-65742fec4787.png">
