### PR TITLE
Add optional deletion reason

### DIFF
--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -6,8 +6,8 @@ class AdsController < ApplicationController
   # rubocop:disable Metrics/AbcSize
   def index
     @ads = Ad.active.strict_loading.includes(:city)
-    @ads = @ads.order(created_at: :desc).paginate(page: params[:page], per_page: 20)
-    @ads = @ads.where(kind: ad_kind)
+    @ads = @ads.ordered.paginate(page: params[:page], per_page: 20)
+    @ads = @ads.for_kind(ad_kind)
     @ads = @ads.where(category: params[:category]) if params[:category].present?
     @ads = @ads.where(city_id: params[:city_id]) if params[:city_id].present?
   end
@@ -50,7 +50,7 @@ class AdsController < ApplicationController
     @ad = Ad.active.find(params[:id])
     redirect_to ad_path(@ad), alert: t("ad.delete_not_allowed") if token_invalid?
 
-    @ad.soft_delete!
+    @ad.soft_delete!(params[:delete_reason], params[:delete_comment])
     redirect_to ads_path, notice: "Oglas obrisan."
   end
 

--- a/app/helpers/ads_helper.rb
+++ b/app/helpers/ads_helper.rb
@@ -30,6 +30,11 @@ module AdsHelper
     Ad.kinds.keys.map { |key| [t("ad.kinds.#{key}"), key] }
   end
 
+  def delete_reasons_for_select(ad_kind)
+    Reason::DELETE_REASONS.slice(ad_kind.to_sym, :common).values.flat_map(&:keys)
+                          .map { |reason| [I18n.t("reason.delete_reasons.#{reason}"), reason] }
+  end
+
   def cities_for_filter_select
     City.where(id: Ad.active.where(kind: ad_kind).select("DISTINCT(city_id)")).order(:name).pluck(:name, :id)
   end

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -48,10 +48,13 @@ class Ad < ApplicationRecord
   KINDS = %w[supply demand].freeze
 
   belongs_to :city
+  has_one :reason, dependent: :delete
 
   include SoftlyDeletable
 
   scope :active, -> { not_deleted }
+  scope :ordered, -> { order(created_at: :desc) }
+  scope :for_kind, ->(kind) { where(kind: kind) }
 
   validates :description, presence: true
   validates :phone, presence: true, on: %i[create update]

--- a/app/models/concerns/softly_deletable.rb
+++ b/app/models/concerns/softly_deletable.rb
@@ -8,7 +8,9 @@ module SoftlyDeletable
     scope :not_deleted, -> { where(deleted_at: nil) }
   end
 
-  def soft_delete!
+  def soft_delete!(reason_code = nil, comment = nil)
+    Reason.create(ad: self, code: reason_code, comment: comment) if reason_code || comment
+
     update!(deleted_at: Time.zone.now)
   end
 end

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reasons
+#
+#  id         :bigint           not null, primary key
+#  code       :integer
+#  comment    :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  ad_id      :bigint           not null
+#
+# Indexes
+#
+#  index_reasons_on_ad_id  (ad_id)
+#
+class Reason < ApplicationRecord
+  belongs_to :ad
+
+  DELETE_REASONS = {
+    common: {
+      other: 0,
+    },
+    demand: {
+      got_help_here: 1,
+      got_help_elsewhere: 2,
+      solved_problem_ourselves: 3,
+    },
+    supply: {
+      gave_help_here: 4,
+      gave_help_elsewhere: 5,
+      cannot_give_help_anymore: 6,
+    },
+  }.freeze
+
+  enum code: DELETE_REASONS.values.reduce(&:merge)
+end

--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -1,4 +1,4 @@
-<div class="tile is-parent mb-2 is-12">
+<div class="ad-card tile is-parent mb-2 is-12">
   <div class="tile is-child card is-flex is-flex-direction-column">
     <div class="card-content" data-controller="card-dropdown">
 

--- a/app/views/ads/delete/new.html.erb
+++ b/app/views/ads/delete/new.html.erb
@@ -3,6 +3,26 @@
 <%= form_with url: ad_path(@ad), method: :delete do |f| %>
   <%= hidden_field_tag :t, params[:t] %>
 
+  <div class="field">
+    <%= t("ad.delete_reason_request") %>
+  </div>
+
+  <div class="field">
+    <%= f.label :delete_reason, class: "label" %>
+    <div class="control">
+      <div class="select">
+        <%= f.select :delete_reason, delete_reasons_for_select(@ad.kind), prompt: '-- Razlog za brisanje --' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="field">
+    <%= f.label :delete_comment, class: "label" %>
+    <div class="control">
+      <%= f.text_field :delete_comment, class: "input" %>
+    </div>
+  </div>
+
   <div class="is-flex is-align-items-center">
     <%= f.submit "Obriši", class: "button is-danger" %>
     <%= link_to "Odustani", ad_path(@ad), class: "has-text-grey ml-4" %>

--- a/config/locales/app.hr.yml
+++ b/config/locales/app.hr.yml
@@ -16,7 +16,19 @@ hr:
     kinds:
       demand: Tražim pomoć
       supply: Nudim pomoć
+    delete_reason_request: |
+      Ova stranica je nastala volonterskim radom i htijeli bi ocijeniti koliko je korisna bila i kako ju možemo učiniti korisnijom.
+      To je potpuno opcionalno ali pomoglo bi nam kada biste naveli razlog zašto oglas više nije relevantan. Hvala!
 
+  reason:
+    delete_reasons:
+      other: Ostalo
+      got_help_here: Dobili smo pomoć preko ove stranice
+      got_help_elsewhere: Dobili smo pomoć preko drugog kanala
+      solved_problem_ourselves: Sami smo riješili problem i više nam ne treba pomoć
+      gave_help_here: Kontaktirali su nas preko ove stranice i dali smo pomoć
+      gave_help_elsewhere: Kontaktirali su nas drugim kanalom i dali smo pomoć
+      cannot_give_help_anymore: Više nismo u mogućnosti ponuditi pomoć
 
   tokens:
     action:
@@ -49,6 +61,8 @@ hr:
         name: Ime
   helpers:
     label:
+      delete_reason: "Razlog za brisanje"
+      delete_comment: "Dodatno pojašnjenje (opcionalno)"
       ad:
         address: "Adresa *"
         city: "Grad *"

--- a/db/migrate/20210109210542_create_reasons.rb
+++ b/db/migrate/20210109210542_create_reasons.rb
@@ -1,0 +1,11 @@
+class CreateReasons < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reasons do |t|
+      t.references :ad, null: false
+      t.integer :code
+      t.string :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_04_195316) do
+ActiveRecord::Schema.define(version: 2021_01_09_210542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,15 @@ ActiveRecord::Schema.define(version: 2021_01_04_195316) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_counties_on_name"
+  end
+
+  create_table "reasons", force: :cascade do |t|
+    t.bigint "ad_id", null: false
+    t.integer "code"
+    t.string "comment"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["ad_id"], name: "index_reasons_on_ad_id"
   end
 
   add_foreign_key "ads", "cities"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,7 +22,7 @@ number_of_ads.times do
     city_id: cities.sample,
     phone: '0' + rand(9_000_00_00..9_999_99_99).to_s,
     description: FFaker::Lorem.paragraph,
-    email: rand(0..number_of_ads) < 40 ? FFaker::Internet.email : nil, # 40% chance ad has email
+    email: rand < 0.4 ? FFaker::Internet.email : nil, # 40% chance ad has email
     kind: Ad::KINDS.sample,
     consent: true,
     address: FFaker::Address.street_name,

--- a/spec/features/delete_an_ad_spec.rb
+++ b/spec/features/delete_an_ad_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Ad deleting", type: :system do
+  let(:topmost_ad) { Ad.ordered.for_kind("supply").first }
+
+  before do
+    # Ensure that topmost ad is editable
+    topmost_ad.update!(email: "tester@example.com")
+  end
+
+  def delete_link_from_last_email
+    email_body = ActionMailer::Base.deliveries.last.body.to_s
+    delete_links = email_body.scan(%r{http://.+/delete/new\?t=[0-9a-f]+})
+    raise "Expected exactly one delete link in email but found #{delete_links.size}" unless delete_links.size == 1
+    delete_links.first
+  end
+
+  def open_topmost_ad_delete_form
+    within(first(:css, ".ad-card")) do
+      expect(page).to have_content topmost_ad.description
+      find(".dropdown-trigger").click
+      click_on("Obriši oglas")
+    end
+  end
+
+  it "remove the ad from the list" do
+    visit "/"
+    open_topmost_ad_delete_form
+
+    fill_in "Email", with: topmost_ad.email
+    click_on "Pošalji"
+
+    visit delete_link_from_last_email
+    click_on "Obriši"
+
+    expect(page).to have_content "Oglas obrisan"
+    expect(page).not_to have_content topmost_ad.description
+  end
+end

--- a/spec/features/delete_an_ad_spec.rb
+++ b/spec/features/delete_an_ad_spec.rb
@@ -5,37 +5,56 @@ require "rails_helper"
 RSpec.describe "Ad deleting", type: :system do
   let(:topmost_ad) { Ad.ordered.for_kind("supply").first }
 
-  before do
-    # Ensure that topmost ad is editable
-    topmost_ad.update!(email: "tester@example.com")
-  end
-
   def delete_link_from_last_email
     email_body = ActionMailer::Base.deliveries.last.body.to_s
     delete_links = email_body.scan(%r{http://.+/delete/new\?t=[0-9a-f]+})
     raise "Expected exactly one delete link in email but found #{delete_links.size}" unless delete_links.size == 1
+
     delete_links.first
   end
 
   def open_topmost_ad_delete_form
     within(first(:css, ".ad-card")) do
-      expect(page).to have_content topmost_ad.description
       find(".dropdown-trigger").click
       click_on("Obriši oglas")
     end
   end
 
-  it "remove the ad from the list" do
-    visit "/"
-    open_topmost_ad_delete_form
-
-    fill_in "Email", with: topmost_ad.email
+  def submit_request_to_delete(with:)
+    fill_in "Email", with: with
     click_on "Pošalji"
+  end
 
+  before do
+    # Ensure that topmost ad is editable
+    topmost_ad.update!(email: "tester@example.com", created_at: Time.zone.now)
+
+    visit "/"
+    expect(page).to have_content topmost_ad.description
+    open_topmost_ad_delete_form
+    submit_request_to_delete with: topmost_ad.email
     visit delete_link_from_last_email
+  end
+
+  it "removes the ad from the list" do
     click_on "Obriši"
 
     expect(page).to have_content "Oglas obrisan"
     expect(page).not_to have_content topmost_ad.description
+  end
+
+  it "allows specifying reason and comment for deletion" do
+    old_reason_count = Reason.count
+
+    select "Kontaktirali su nas preko ove stranice", from: "Razlog za brisanje"
+    fill_in "Dodatno pojašnjenje", with: "Proslo je dobro"
+
+    click_on "Obriši"
+
+    expect(page).not_to have_content topmost_ad.description
+    expect(Reason.count).to eq old_reason_count + 1
+    reason = Reason.last
+    expect(reason.code).to eq "gave_help_here"
+    expect(reason.comment).to eq "Proslo je dobro"
   end
 end

--- a/spec/models/reason_spec.rb
+++ b/spec/models/reason_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reasons
+#
+#  id         :bigint           not null, primary key
+#  code       :integer
+#  comment    :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  ad_id      :bigint           not null
+#
+# Indexes
+#
+#  index_reasons_on_ad_id  (ad_id)
+#
+require "rails_helper"
+
+RSpec.describe Reason, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Resolves: #117

Optionally, when deleting the ad the user can
    select a reason from the dropdown and provide
    a comment.

This is not shown anywhere in the app, it's for
    us to analyse later.
    
<img width="1181" alt="Screenshot 2021-01-11 at 23 10 10" src="https://user-images.githubusercontent.com/1065097/104244188-381ec180-5462-11eb-96a5-164125eae793.png">
