### PR TITLE
Fix: City Search: Always remove accents before comparing names

### DIFF
--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -15,6 +15,6 @@ class CitiesController < ApplicationController
   def cities_search(query)
     return City.none if query.blank? || query.length < 3
 
-    City.strict_loading.where("unaccent(name) ILIKE ?", "#{query}%").select(:id, :name).limit(100)
+    City.strict_loading.where("unaccent(name) ILIKE unaccent(?)", "#{query}%").select(:id, :name).limit(100)
   end
 end


### PR DESCRIPTION
The issue happened when user typed accented characters, for example "čak" for "Čakovec". We'd unaccent the city name in the database ("Cakovec"), but we didn't unaccent what user typed ("čak") and so there was no match between the two.