### PR TITLE
Add back mailer preview for send_token

### DIFF
--- a/spec/mailers/previews/ad_mailer_preview.rb
+++ b/spec/mailers/previews/ad_mailer_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/ad_mailer
+class AdMailerPreview < ActionMailer::Preview
+  def send_token
+    ad = Ad.new(id: 123, token: "a1b2c3d4")
+    action = params[:a].presence || "edit"
+    AdMailer.send_token(ad, action, "http://www.example.com/ads/123/edit?t=a1b2c3d4")
+  end
+end


### PR DESCRIPTION
I was searching for this preview to link to it in one of the PRs, but couldn't find it so I remembered it was in `/test` directory and dug it up. :)