### PR TITLE
Add a reminder to be sent 2 days after ad creation

### DIFF
--- a/app/controllers/ads/token_controller.rb
+++ b/app/controllers/ads/token_controller.rb
@@ -27,7 +27,7 @@ class Ads::TokenController < ApplicationController
   end
 
   def send_token(ad)
-    ad.update!(token: SecureRandom.hex)
+    ad.refresh_token!
     AdMailer.send_token(ad, params[:a], build_url(ad, action)).deliver_later
   end
 

--- a/app/mailers/ad_mailer.rb
+++ b/app/mailers/ad_mailer.rb
@@ -8,4 +8,12 @@ class AdMailer < ApplicationMailer
     @url = url
     mail to: ad.email, subject: "Link za #{@action} oglasa"
   end
+
+  def send_reminder(ad, ad_link, edit_url, delete_url)
+    @creation_date = ad.created_at.to_date
+    @ad_link = ad_link
+    @edit_url = edit_url
+    @delete_url = delete_url
+    mail to: ad.email, subject: "Vaš oglas na potres-petrinja.hr"
+  end
 end

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -4,20 +4,21 @@
 #
 # Table name: ads
 #
-#  id          :bigint           not null, primary key
-#  address     :string
-#  category    :integer          default("accomodation"), not null
-#  consent     :boolean
-#  deleted_at  :datetime
-#  description :text
-#  email       :string
-#  kind        :integer          default("supply"), not null
-#  phone       :string
-#  token       :string
-#  zip         :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  city_id     :bigint           not null
+#  id               :bigint           not null, primary key
+#  address          :string
+#  category         :integer          default("accomodation"), not null
+#  consent          :boolean
+#  deleted_at       :datetime
+#  description      :text
+#  email            :string
+#  kind             :integer          default("supply"), not null
+#  phone            :string
+#  reminder_sent_at :datetime
+#  token            :string
+#  zip              :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  city_id          :bigint           not null
 #
 # Indexes
 #
@@ -57,6 +58,9 @@ class Ad < ApplicationRecord
   scope :for_kind, ->(kind) { where(kind: kind) if kind.present? }
   scope :for_category, ->(category) { where(category: category) if category.present? }
   scope :for_city, ->(city) { where(city: city) if city.present? }
+  scope :not_reminded, -> { where(reminder_sent_at: nil) }
+  scope :expiring, -> { where(created_at: ..2.days.ago) }
+  scope :with_email, -> { where.not(email: nil) }
 
   validates :description, presence: true
   validates :phone, presence: true, on: %i[create update]
@@ -82,6 +86,10 @@ class Ad < ApplicationRecord
 
   def editable?
     email.present?
+  end
+
+  def refresh_token!
+    update!(token: SecureRandom.hex)
   end
 
   def token_valid?(token)

--- a/app/services/ad_reminder.rb
+++ b/app/services/ad_reminder.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# A class to implement all logic related to sending of reminder e-mails
+class AdReminder
+  include Rails.application.routes.url_helpers
+
+  def remind_oldest(batch_size)
+    Ad.with_email.not_deleted.not_reminded.expiring.order(created_at: :asc).limit(batch_size).each do |ad|
+      ad.refresh_token!
+      AdMailer.send_reminder(
+        ad,
+        ad_url(ad),
+        edit_ad_url(ad, t: ad.token),
+        new_ad_delete_url(ad, t: ad.token)
+      ).deliver
+    end
+  end
+end

--- a/app/views/ad_mailer/send_reminder.text.erb
+++ b/app/views/ad_mailer/send_reminder.text.erb
@@ -1,0 +1,16 @@
+Poštovani,
+
+Dana <%= l @creation_date %> objavili ste oglas: <%= @ad_link %>
+
+U svrhu toga da ova stranica bude korisna i da pomoć dođe tamo gdje je potrebna bitno je da su podaci na oglasima ažurni.
+
+Zbog toga bi vas zamolili da po potrebi uredite oglas sa novim informacijama ili ga obrišete ako više nije relevantan:
+
+Ovdje možete urediti oglas: <%= @edit_url %>
+Ovdje možete obrisati oglas: <%= @delete_url %>
+
+Ukoliko ništa ne napravite oglas će naravno i dalje ostati aktivan. Novi link za uređivanje/brisanje možete zatražiti putem internet stranice u bilo kojem trenutku.
+
+Hvala!
+----------
+https://www.potres-petrinja.hr/

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  routes.default_url_options[:host] = "localhost:3000"
+  routes.default_url_options[:protocol] = "http"
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  routes.default_url_options[:host] = "www.potres-petrinja.hr"
+  routes.default_url_options[:protocol] = "https"
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  routes.default_url_options[:host] = "test.app"
+  routes.default_url_options[:protocol] = "http"
+
   config.cache_classes = false
   config.action_view.cache_template_loading = true
 

--- a/db/migrate/20210114201454_add_reminder_fields_to_ad.rb
+++ b/db/migrate/20210114201454_add_reminder_fields_to_ad.rb
@@ -1,0 +1,5 @@
+class AddReminderFieldsToAd < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ads, :reminder_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_09_210542) do
+ActiveRecord::Schema.define(version: 2021_01_14_201454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2021_01_09_210542) do
     t.string "token"
     t.datetime "deleted_at"
     t.bigint "city_id", null: false
+    t.datetime "reminder_sent_at"
     t.index ["category"], name: "index_ads_on_category"
     t.index ["city_id"], name: "index_ads_on_city_id"
     t.index ["created_at"], name: "index_ads_on_created_at"

--- a/lib/tasks/ads.rake
+++ b/lib/tasks/ads.rake
@@ -23,4 +23,11 @@ namespace :ads do
 
     puts "City names normalized!"
   end
+
+  desc "Send reminder emails to remind up to 300 oldest emails to update it."
+  task send_reminders: :environment do
+    count = AdReminder.new.remind_oldest(300).size
+
+    puts "Oldest #{count} emails reminded."
+  end
 end

--- a/spec/factories/ads.rb
+++ b/spec/factories/ads.rb
@@ -6,7 +6,16 @@ FactoryBot.define do
     city
     consent { true }
     description { "Some description." }
-    kind { :supply }
-    phone { "09876543210" }
+    sequence(:kind) { |n| Ad::KINDS[n % Ad::KINDS.size] }
+    sequence(:category) { |n| Ad::CATEGORIES[n % Ad::CATEGORIES.size] }
+    sequence(:phone) { |n| "098/555-#{n}" }
+
+    trait :deleted do
+      deleted_at { Time.zone.now }
+    end
+
+    trait :with_email do
+      sequence(:email) { |n| "tester#{n}@example.com" }
+    end
   end
 end

--- a/spec/factories/cities.rb
+++ b/spec/factories/cities.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :city do
     area_name { "some area" }
     county
-    name { "some city" }
+    sequence(:name) { |n| "City #{n}" }
   end
 end

--- a/spec/factories/counties.rb
+++ b/spec/factories/counties.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :county do
-    name { "Some county" }
+    sequence(:name) { |n| "County #{n}" }
   end
 end

--- a/spec/mailers/previews/ad_mailer_preview.rb
+++ b/spec/mailers/previews/ad_mailer_preview.rb
@@ -3,8 +3,18 @@
 # Preview all emails at http://localhost:3000/rails/mailers/ad_mailer
 class AdMailerPreview < ActionMailer::Preview
   def send_token
-    ad = Ad.new(id: 123, token: "a1b2c3d4")
+    ad = Ad.new(id: 123, token: "a1b2c3d4", email: "tester@example.com")
     action = params[:a].presence || "edit"
     AdMailer.send_token(ad, action, "http://www.example.com/ads/123/edit?t=a1b2c3d4")
+  end
+
+  def send_reminder
+    ad = Ad.new(id: 123, token: "a1b2c3d4", email: "tester@example.com", created_at: Time.zone.now)
+    AdMailer.send_reminder(
+      ad,
+      "http://www.example.com/ads/123",
+      "http://www.example.com/ads/123/edit?t=a1b2c3d4",
+      "http://www.example.com/ads/123/token/new?t=a1b2c3d4"
+    )
   end
 end

--- a/spec/services/ad_reminder_spec.rb
+++ b/spec/services/ad_reminder_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AdReminder do
+  subject(:reminder) { described_class.new }
+
+  describe "#remind_oldest" do
+    subject(:remind_oldest) { reminder.remind_oldest(batch_size) }
+
+    let(:batch_size) { 1 }
+
+    it "sends reminder for an ad that's older than 2 days that wasn't reminded" do
+      ad = create(:ad, :with_email, created_at: 49.hours.ago)
+
+      expect { remind_oldest }.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+      last_delivery = ActionMailer::Base.deliveries.last
+      expect(last_delivery.to).to eq [ad.email]
+      expect(ad.reload.token).to be_present
+      expect(last_delivery.body).to include("edit?t=#{ad.token}")
+      expect(last_delivery.body).to include("delete/new?t=#{ad.token}")
+    end
+
+    it "doesn't send reminder for an ad that's newer than 2 days" do
+      create(:ad, :with_email, created_at: 47.hours.ago)
+
+      expect { remind_oldest }.not_to(change { ActionMailer::Base.deliveries.size })
+    end
+
+    it "doesn't send reminder for an ad that was reminded" do
+      create(:ad, :with_email, created_at: 3.days.ago, reminder_sent_at: 1.day.ago)
+
+      expect { remind_oldest }.not_to(change { ActionMailer::Base.deliveries.size })
+    end
+
+    it "doesn't try to send reminder for an ad without an email" do
+      create(:ad, email: nil, created_at: 3.days.ago)
+
+      expect { remind_oldest }.not_to(change { ActionMailer::Base.deliveries.size })
+    end
+
+    it "doesn't try to send reminder for an ad that was deleted" do
+      create(:ad, :deleted, :with_email, created_at: 49.hours.ago)
+
+      expect { remind_oldest }.not_to(change { ActionMailer::Base.deliveries.size })
+    end
+  end
+end


### PR DESCRIPTION
Resolves: #121 

This adds a new reminder e-mail that reminds people
to edit or delete an ad to keep ads relevant.

The rake task is intended to be run by heroku scheduler
and it reminds only 300 oldest emails. That because
the e-mail plan we have supports 400 emails a day
on average and we don't want to eat the quota for other
emails. We have a backlog of unreminded e-mails and
the nighly job will just work through them over several
days.