### PR TITLE
Make Ad reminder resilient to failures and set reminder timestamp

### DIFF
--- a/spec/services/ad_reminder_spec.rb
+++ b/spec/services/ad_reminder_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe AdReminder do
 
       last_delivery = ActionMailer::Base.deliveries.last
       expect(last_delivery.to).to eq [ad.email]
-      expect(ad.reload.token).to be_present
+      ad.reload
+      expect(ad.token).to be_present
+      expect(ad.reminder_sent_at).to be_present
       expect(last_delivery.body).to include("edit?t=#{ad.token}")
       expect(last_delivery.body).to include("delete/new?t=#{ad.token}")
     end


### PR DESCRIPTION
In the previous iteration I forgot to set the reminder timestamp
but also, the reminder was not resilient to one ad being problematic.
If an ad was problematic it would just fail and not process other
ads in the batch.

Both of those issues are fixed here.